### PR TITLE
Added customizable authentication failure HTTP code and location header

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var express = require('express'), app = express(), cs = require('cansecurity'), 
 
 	// only authorized if logged in, or as certain roles, or some combination
 	app.get("/secure/loggedin",cansec.restrictToLoggedIn,send200);
-	app.get("/secure/customloggedin",cansec.unauthenticated({code:302,location:"/login"}),cansec.restrictToLoggedIn,send200);
+	app.get("/secure/customloggedin",cansec.setUnauthenticatedCode({code:302,location:"/login"}),cansec.restrictToLoggedIn,send200);
 	app.get("/secure/user/:user",cansec.restrictToSelf,send200);
 	app.get("/secure/roles/admin",cansec.restrictToRoles("admin"),send200);
 	app.get("/secure/roles/adminOrSuper",cansec.restrictToRoles(["admin","super"]),send200);

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ var express = require('express'), app = express(), cs = require('cansecurity'), 
 
 	// only authorized if logged in, or as certain roles, or some combination
 	app.get("/secure/loggedin",cansec.restrictToLoggedIn,send200);
+	app.get("/secure/customloggedin",cansec.unauthenticated({code:302,location:"/login"}),cansec.restrictToLoggedIn,send200);
 	app.get("/secure/user/:user",cansec.restrictToSelf,send200);
 	app.get("/secure/roles/admin",cansec.restrictToRoles("admin"),send200);
 	app.get("/secure/roles/adminOrSuper",cansec.restrictToRoles(["admin","super"]),send200);

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -4,10 +4,14 @@ const errors = require('./errors'), rparams = require('./param'), sender = requi
   csauth = constants.header.AUTH,
   fields = {}, params = {};
 
-const checkLoggedIn = (req, res, next, unauthCode = HttpStatus.UNAUTHORIZED, unauthLocation = null) => {
+const checkLoggedIn = (req, res, next) => {
     // If our user is authenticated
     // then everything is fine :)
-    let logged = true;
+    let logged = true, 
+        unauthenticatedResponse = req.unauthenticatedResponse || {}
+        unauthCode = unauthenticatedResponse.code || HttpStatus.UNAUTHORIZED;
+        unauthLocation = unauthenticatedResponse.location || null;
+
     rparams(req);
     if (!req[csauth]) {
       if (unauthLocation != null) {
@@ -104,9 +108,10 @@ const checkLoggedIn = (req, res, next, unauthCode = HttpStatus.UNAUTHORIZED, una
       }
     },
     indirect: {
-      unauthenticated: (unauthenticatedResponse) => {
-        return (req, res, next) => {
-          checkLoggedIn(req, res, next, unauthenticatedResponse.code, unauthenticatedResponse.location) && next();
+      setUnauthenticatedCode: (unauthenticatedResponse) => {
+        return (req, res, next) => { 
+          req.unauthenticatedResponse = unauthenticatedResponse;
+          next()
         };
       },
       // valid if user is logged in *and* the logged-in user has at least one of the given roles

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -1,24 +1,19 @@
 /*jslint node:true, nomen:false, unused:vars */
 const errors = require('./errors'), rparams = require('./param'), sender = require('./sender'),
-  constants = require('./constants').get(),
+  constants = require('./constants').get(), HttpStatus = require('http-status-codes'),
   csauth = constants.header.AUTH,
   fields = {}, params = {};
-// initialize [TODO: overridable] global default
-var unauthenticatedcode = constants.httpcodes.UNAUTHENTICATED;
 
-const checkLoggedIn = (req, res, next, unauthenticatedResponse = {code:unauthenticatedcode}) => {
+const checkLoggedIn = (req, res, next, unauthCode = HttpStatus.UNAUTHORIZED, unauthLocation = null) => {
     // If our user is authenticated
     // then everything is fine :)
     let logged = true;
     rparams(req);
     if (!req[csauth]) {
-      unauthenticatedResponse = unauthenticatedResponse || {code:unauthenticatedcode};
-      unauthenticatedResponse.code = unauthenticatedResponse.code || unauthenticatedcode; 
-      unauthenticatedResponse.location = unauthenticatedResponse.location || null; 
-      if (unauthenticatedResponse.location != null) {
-        res.header("location", unauthenticatedResponse.location);
+      if (unauthLocation != null) {
+        res.header("location", unauthLocation);
       }
-      sender(res,unauthenticatedResponse.code,errors.unauthenticated(),unauthenticatedResponse);
+      sender(res,unauthCode,errors.unauthenticated());
       logged = false;
     }
     return (logged);
@@ -111,7 +106,7 @@ const checkLoggedIn = (req, res, next, unauthenticatedResponse = {code:unauthent
     indirect: {
       unauthenticated: (unauthenticatedResponse) => {
         return (req, res, next) => {
-          checkLoggedIn(req, res, next, unauthenticatedResponse) && next();
+          checkLoggedIn(req, res, next, unauthenticatedResponse.code, unauthenticatedResponse.location) && next();
         };
       },
       // valid if user is logged in *and* the logged-in user has at least one of the given roles

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -3,14 +3,20 @@ const errors = require('./errors'), rparams = require('./param'), sender = requi
   constants = require('./constants').get(),
   csauth = constants.header.AUTH,
   fields = {}, params = {};
-const checkLoggedIn = (req, res, next, unauthenticatedResponse = {code:401,location:null}) => {
+// initialize [TODO: overridable] global default
+var unauthenticatedcode = constants.httpcodes.UNAUTHENTICATED;
+
+const checkLoggedIn = (req, res, next, unauthenticatedResponse = {code:unauthenticatedcode}) => {
     // If our user is authenticated
     // then everything is fine :)
     let logged = true;
     rparams(req);
     if (!req[csauth]) {
+      unauthenticatedResponse = unauthenticatedResponse || {code:unauthenticatedcode};
+      unauthenticatedResponse.code = unauthenticatedResponse.code || unauthenticatedcode; 
+      unauthenticatedResponse.location = unauthenticatedResponse.location || null; 
       if (unauthenticatedResponse.location != null) {
-        res.header("location", unauthenticatedResponse.location)
+        res.header("location", unauthenticatedResponse.location);
       }
       sender(res,unauthenticatedResponse.code,errors.unauthenticated(),unauthenticatedResponse);
       logged = false;

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -3,14 +3,16 @@ const errors = require('./errors'), rparams = require('./param'), sender = requi
   constants = require('./constants').get(),
   csauth = constants.header.AUTH,
   fields = {}, params = {};
-
-const checkLoggedIn = (req, res, next) => {
+const checkLoggedIn = (req, res, next, unauthenticatedResponse = {code:401,location:null}) => {
     // If our user is authenticated
     // then everything is fine :)
     let logged = true;
     rparams(req);
     if (!req[csauth]) {
-      sender(res,401,errors.unauthenticated());
+      if (unauthenticatedResponse.location != null) {
+        res.header("location", unauthenticatedResponse.location)
+      }
+      sender(res,unauthenticatedResponse.code,errors.unauthenticated(),unauthenticatedResponse);
       logged = false;
     }
     return (logged);
@@ -101,6 +103,11 @@ const checkLoggedIn = (req, res, next) => {
       }
     },
     indirect: {
+      unauthenticated: (unauthenticatedResponse) => {
+        return (req, res, next) => {
+          checkLoggedIn(req, res, next, unauthenticatedResponse) && next();
+        };
+      },
       // valid if user is logged in *and* the logged-in user has at least one of the given roles
       restrictToRoles: (roles) => {
         roles = roles ? [].concat(roles) : [];

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -9,9 +9,6 @@ const constants = {
   method: {
     CREDENTIALS :"credentials",
     TOKEN: "token"
-  },
-  httpcodes: {
-    UNAUTHENTICATED: 401
   }
 };
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -9,6 +9,9 @@ const constants = {
   method: {
     CREDENTIALS :"credentials",
     TOKEN: "token"
+  },
+  httpcodes: {
+    UNAUTHENTICATED: 401
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cansecurity",
   "description": "cansecurity is your all-in-one security library for user authentication, authorization and management in node expressjs apps",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "url": "http://github.com/deitch/cansecurity",
   "author": "Avi Deitcher <avi@deitcher.net>",
@@ -17,6 +17,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "async": "^2.5.0",
+    "http-status-codes": "^1.3.0",
     "jsonwebtoken": "^7.4.3",
     "lodash": "^4.17.4"
   },

--- a/test/test-authorization.js
+++ b/test/test-authorization.js
@@ -318,7 +318,7 @@ alltests = function () {
 setpaths = function () {
 	app.get('/secure/fieldOrRole',cansec.restrictToFieldOrRoles("owner","admin",getCheckObject),send200);
 	app.get("/secure/loggedin",cansec.restrictToLoggedIn,send200);
-	app.get("/secure/customloggedin",cansec.unauthenticated({code:302,location:"/login"}),cansec.restrictToLoggedIn,send200);
+	app.get("/secure/customloggedin",cansec.setUnauthenticatedCode({code:302,location:"/login"}),cansec.restrictToLoggedIn,send200);
 	app.get("/secure/user/:user",cansec.restrictToSelf,send200);
 	app.get("/secure/roles/admin",cansec.restrictToRoles("admin"),send200);
 	app.get("/secure/roles/adminOrSuper",cansec.restrictToRoles(["admin","super"]),send200);

--- a/test/test-authorization.js
+++ b/test/test-authorization.js
@@ -12,6 +12,15 @@ getCheckObject = function(req,res) {
 	return({owner:"2",recipient:"4"});
 },
 alltests = function () {
+  describe('Authorization', function(){
+		before(function(){
+		  path = '/secure/customloggedin';
+		  location = '/login';
+		});
+		it('should reject with custom HTTP code when not logged in',function (done) {
+			r.get(path).set('Accept', 'text/plain').expect('location', location).expect(302,unauthenticated,done);
+		});
+  });
   describe('logged in path', function(){
 		before(function(){
 		  path = '/secure/loggedin';
@@ -309,6 +318,7 @@ alltests = function () {
 setpaths = function () {
 	app.get('/secure/fieldOrRole',cansec.restrictToFieldOrRoles("owner","admin",getCheckObject),send200);
 	app.get("/secure/loggedin",cansec.restrictToLoggedIn,send200);
+	app.get("/secure/customloggedin",cansec.unauthenticated({code:302,location:"/login"}),cansec.restrictToLoggedIn,send200);
 	app.get("/secure/user/:user",cansec.restrictToSelf,send200);
 	app.get("/secure/roles/admin",cansec.restrictToRoles("admin"),send200);
 	app.get("/secure/roles/adminOrSuper",cansec.restrictToRoles(["admin","super"]),send200);


### PR DESCRIPTION
Fix for issue #20
Can customize authentication failure HTTP response code and location header for the routes as below
`app.get("/secure/customloggedin",cansec.unauthenticated({code:302,location:"/login"}),cansec.restrictToLoggedIn,send200); 
`